### PR TITLE
Update Archive.scala

### DIFF
--- a/core/src/main/scala/cilib/Archive.scala
+++ b/core/src/main/scala/cilib/Archive.scala
@@ -41,7 +41,7 @@ sealed abstract class Archive[A] {
               NonEmpty[A](v :: l, b, c)
             else if (l.size >= limit.value && l.forall(x => c(v, x))) {
               val selected = deletePolicy(l)
-              NonEmpty[A](l.filterNot(x => x.equals(selected)), b, c)
+              NonEmpty[A](v :: l.filterNot(x => x.equals(selected)), b, c)
             } else
               NonEmpty[A](l, b, c)
           case Unbounded() =>


### PR DESCRIPTION
Update insert function to also add the new value if the bounded archive is full and the condition holds (Line 43):
NonEmpty[A](v :: l.filterNot(x => x.equals(selected)), b, c)